### PR TITLE
manifest: nrf_modem: v1.5.2

### DIFF
--- a/lib/nrf_modem_lib/TEST_CHANGE.txt
+++ b/lib/nrf_modem_lib/TEST_CHANGE.txt
@@ -1,0 +1,1 @@
+Test change to nrf

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: eb0a5b6574d7cd1942ffce0d7424528565de1cb2
+      revision: pull/4/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: fd79b800bddf63b0a212a70007a6b612226e134c
+      revision: pull/4/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Update manifest for nrf_modem v1.5.2 release.

Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>
Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>
